### PR TITLE
feat: add production browser console control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-08-17
+
+### Added
+
+- Added `browserConsole` configuration for browser output control:
+  - `localhost` logs only on local browser hosts (default)
+  - `always` opts into browser console output on any host
+  - `never` disables default browser console output
+
+### Changed
+
+- Suppressed default browser console output on non-localhost production hosts unless explicitly overridden.
+- Centralized default output handling across logger and internal diagnostics.
+- Enforced configured AI rate limits before external provider calls.
+
 ## [1.2.1] - 2026-08-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **Beautiful colored output** with timestamps and file locations
 - **AI-powered error analysis** with intelligent insights and fix suggestions
 - **Structured JSON logging** for production environments
+- **Browser-safe defaults** that suppress console output on non-localhost web hosts
 - **Security hardened** with input validation and sanitization
 - **TypeScript first** with full type safety
 - **Zero dependencies** for core functionality (AI features optional)
@@ -88,6 +89,7 @@ const logger = new Logger({
   showSource: true,
   prefix: '[MY-APP]',
   json: false, // Set to true for production
+  browserConsole: 'localhost', // 'localhost' | 'always' | 'never'
   ai: {
     enabled: true,
     provider: 'ollama', // 'openai' | 'claude' | 'disabled'
@@ -95,6 +97,21 @@ const logger = new Logger({
   },
 });
 ```
+
+### Browser Production Console Policy
+
+When no custom `output` stream is provided, browser console output is enabled only on
+`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, or `*.localhost`. Production web hosts
+silently no-op by default so bundled apps do not write to Chrome DevTools unless you
+explicitly opt in:
+
+```typescript
+const logger = new Logger({
+  browserConsole: 'always', // override for production browser diagnostics
+});
+```
+
+Passing a custom `output` stream always takes precedence.
 
 ## Factory Methods
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calphonse/logger",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Colored logging utility with chalk for Node.js applications",
   "author": "Christopher Alphonse",
   "homepage": "https://github.com/ChristopherAlphonse/logger",

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -170,6 +170,106 @@ describe('Logger', () => {
     });
   });
 
+  describe('browser console output policy', () => {
+    const originalProcess = globalThis.process;
+    const originalWindow = (globalThis as typeof globalThis & { window?: unknown }).window;
+    const originalLocation = (globalThis as typeof globalThis & { location?: unknown }).location;
+
+    const setBrowserHost = (hostname: string) => {
+      Object.defineProperty(globalThis, 'process', {
+        value: undefined,
+        configurable: true,
+      });
+      Object.defineProperty(globalThis, 'window', {
+        value: {},
+        configurable: true,
+      });
+      Object.defineProperty(globalThis, 'location', {
+        value: { hostname },
+        configurable: true,
+      });
+    };
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'process', {
+        value: originalProcess,
+        configurable: true,
+      });
+
+      if (originalWindow === undefined) {
+        Reflect.deleteProperty(globalThis, 'window');
+      } else {
+        Object.defineProperty(globalThis, 'window', {
+          value: originalWindow,
+          configurable: true,
+        });
+      }
+
+      Object.defineProperty(globalThis, 'location', {
+        value: originalLocation,
+        configurable: true,
+      });
+
+      jest.restoreAllMocks();
+    });
+
+    test('should suppress default browser console output on non-local hosts', () => {
+      setBrowserHost('app.example.com');
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+      const browserLogger = new Logger({ colors: false, showSource: false });
+      browserLogger.info('production browser message');
+
+      expect(infoSpy).not.toHaveBeenCalled();
+    });
+
+    test('should allow default browser console output on localhost', () => {
+      setBrowserHost('localhost');
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+      const browserLogger = new Logger({ colors: false, showSource: false });
+      browserLogger.info('local browser message');
+
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('local browser message'));
+    });
+
+    test('should allow browser console output on non-local hosts when explicitly enabled', () => {
+      setBrowserHost('app.example.com');
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+
+      const browserLogger = new Logger({
+        browserConsole: 'always',
+        colors: false,
+        showSource: false,
+      });
+      browserLogger.info('explicit browser message');
+
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('explicit browser message'));
+    });
+
+    test('should honor explicit output streams even when browser console is disabled', () => {
+      setBrowserHost('app.example.com');
+      const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+      const writes: string[] = [];
+
+      const browserLogger = new Logger({
+        browserConsole: 'never',
+        colors: false,
+        output: {
+          write: (chunk: string) => {
+            writes.push(chunk);
+            return true;
+          },
+        },
+        showSource: false,
+      });
+      browserLogger.info('custom output message');
+
+      expect(infoSpy).not.toHaveBeenCalled();
+      expect(writes.join('')).toContain('custom output message');
+    });
+  });
+
   describe('child loggers', () => {
     test('should create child logger with prefix', () => {
       const parentLogger = new Logger({ level: LogLevel.INFO });

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -84,6 +84,7 @@ describe('Types', () => {
         prefix: 'TEST',
         json: true,
         output: mockStream as unknown as NodeJS.WritableStream,
+        browserConsole: 'localhost',
       };
 
       expect(config.level).toBe(LogLevel.DEBUG);
@@ -94,6 +95,7 @@ describe('Types', () => {
       expect(config.prefix).toBe('TEST');
       expect(config.json).toBe(true);
       expect(config.output).toBe(mockStream);
+      expect(config.browserConsole).toBe('localhost');
     });
 
     it('should allow partial configuration', () => {

--- a/src/ai-service.ts
+++ b/src/ai-service.ts
@@ -156,7 +156,7 @@ export class AIService implements IAIService {
           return true;
 
         case 'openai':
-          if (!this.openai || !this.openai.models) return false;
+          if (!this.openai?.models) return false;
           await this.openai.models.list();
           return true;
 
@@ -187,6 +187,11 @@ export class AIService implements IAIService {
       }
     }
 
+    if (!this.checkRateLimit()) {
+      internalLogger.warn('AI rate limit exceeded, using basic insights');
+      return this.generateBasicInsight(error, this.detectFramework([], error.message) || 'unknown');
+    }
+
     const insight = await this.generateInsight(error, context);
     insight.processingTime = Date.now() - startTime;
 
@@ -215,6 +220,12 @@ export class AIService implements IAIService {
     }
 
     const framework = this.detectFramework(stackTrace, '');
+
+    if (!this.checkRateLimit()) {
+      internalLogger.warn('AI rate limit exceeded, using basic stack trace insights');
+      return this.generateBasicInsight(new Error('Stack trace analysis'), framework);
+    }
+
     const insight = await this.generateStackTraceInsight(stackTrace, framework, context);
     insight.processingTime = Date.now() - startTime;
 
@@ -624,6 +635,11 @@ Provide analysis in JSON format.`;
     }
 
     if (!config.translateLogLevels.includes(level)) {
+      return message;
+    }
+
+    if (!this.checkRateLimit()) {
+      internalLogger.warn('AI rate limit exceeded, using original log message');
       return message;
     }
 

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -15,28 +15,29 @@ declare const window:
       localStorage?: Storage;
     }
   | undefined;
-declare const localStorage: Storage | undefined;
+
+function getBrowserLocalStorage(): Storage | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  return window.localStorage;
+}
+
+function getStorageKey(path: string): string {
+  return `logger-config-${path.replace(/[^a-zA-Z0-9]/g, '_')}`;
+}
 
 const browserFS = {
   readFileSync: (path: string, _encoding: string) => {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      const key = `logger-config-${path.replace(/[^a-zA-Z0-9]/g, '_')}`;
-      return localStorage?.getItem(key) || '{}';
-    }
-    return '{}';
+    return getBrowserLocalStorage()?.getItem(getStorageKey(path)) || '{}';
   },
   writeFileSync: (path: string, data: string, _encoding: string) => {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      const key = `logger-config-${path.replace(/[^a-zA-Z0-9]/g, '_')}`;
-      localStorage?.setItem(key, data);
-    }
+    getBrowserLocalStorage()?.setItem(getStorageKey(path), data);
   },
   existsSync: (path: string) => {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      const key = `logger-config-${path.replace(/[^a-zA-Z0-9]/g, '_')}`;
-      return localStorage?.getItem(key) !== null;
-    }
-    return false;
+    const storage = getBrowserLocalStorage();
+    return storage ? storage.getItem(getStorageKey(path)) !== null : false;
   },
 };
 

--- a/src/console-utils.ts
+++ b/src/console-utils.ts
@@ -79,7 +79,7 @@ export function formatString(
   ...args: unknown[]
 ): { message: string; data?: unknown } {
   let message = format;
-  let data: unknown = undefined;
+  let data: unknown;
   let argIndex = 0;
 
   message = message.replace(/%([sdioOcf])/g, (match, specifier) => {

--- a/src/internalLogger.ts
+++ b/src/internalLogger.ts
@@ -1,3 +1,5 @@
+import { createDefaultOutput } from './output-policy';
+
 class SimpleInternalLogger {
   constructor(private prefix: string) {}
 
@@ -6,11 +8,11 @@ class SimpleInternalLogger {
       ? `${this.prefix} ${message} ${JSON.stringify(data)}\n`
       : `${this.prefix} ${message}\n`;
 
-    if (typeof process !== 'undefined' && process.stderr) {
-      process.stderr.write(output);
-    } else {
-      console.warn(output.trim());
-    }
+    const stream =
+      typeof process !== 'undefined' && process.stderr
+        ? process.stderr
+        : createDefaultOutput('localhost');
+    stream.write(output);
   }
 
   error(message: string, data?: unknown): void {
@@ -18,11 +20,11 @@ class SimpleInternalLogger {
       ? `${this.prefix} ${message} ${JSON.stringify(data)}\n`
       : `${this.prefix} ${message}\n`;
 
-    if (typeof process !== 'undefined' && process.stderr) {
-      process.stderr.write(output);
-    } else {
-      console.error(output.trim());
-    }
+    const stream =
+      typeof process !== 'undefined' && process.stderr
+        ? process.stderr
+        : createDefaultOutput('localhost');
+    stream.write(output);
   }
 
   info(message: string, data?: unknown): void {
@@ -30,11 +32,7 @@ class SimpleInternalLogger {
       ? `${this.prefix} ${message} ${JSON.stringify(data)}\n`
       : `${this.prefix} ${message}\n`;
 
-    if (typeof process !== 'undefined' && process.stdout) {
-      process.stdout.write(output);
-    } else {
-      console.info(output.trim());
-    }
+    createDefaultOutput('localhost').write(output);
   }
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,7 +4,15 @@ import { ConfigManager } from './config-manager';
 import { processConsoleArgs } from './console-utils';
 import { LogFormatter } from './formatters';
 import { createInternalLogger } from './internalLogger';
-import { type ILogger, type LogData, type LogEntry, LogLevel, type LoggerConfig } from './types';
+import { createDefaultOutput } from './output-policy';
+import {
+  type ILogger,
+  type LogData,
+  type LogEntry,
+  LogLevel,
+  type LoggerConfig,
+  type LoggerOutput,
+} from './types';
 import type { AIInsight, ErrorAnalysis } from './types';
 
 const chalk =
@@ -25,18 +33,17 @@ export class Logger implements ILogger {
       showSource: true,
       prefix: '',
       json: false,
-      output:
-        typeof process !== 'undefined' && process.stdout ? process.stdout : { write: console.log },
+      browserConsole: 'localhost',
       ...config,
     };
+    this.config.output ??= createDefaultOutput(this.config.browserConsole);
 
     if (this.config.output && !this.isValidOutputStream(this.config.output)) {
       const internalLogger = createInternalLogger('[LOGGER]');
       internalLogger.warn(
         'Invalid output stream provided in configuration. Falling back to process.stdout. Please check your logger configuration.'
       );
-      this.config.output =
-        typeof process !== 'undefined' && process.stdout ? process.stdout : { write: console.log };
+      this.config.output = createDefaultOutput(this.config.browserConsole);
     }
 
     this.formatter = new LogFormatter();
@@ -159,10 +166,6 @@ export class Logger implements ILogger {
     }
   }
 
-  private getLevelColor(_level: LogLevel): ((text: string) => string) | null {
-    return null;
-  }
-
   private shouldTranslateLog(level: LogLevel): boolean {
     if (!this.aiService) return false;
 
@@ -203,6 +206,7 @@ export class Logger implements ILogger {
 
   setConfig(config: Partial<LoggerConfig>): void {
     this.config = { ...this.config, ...config };
+    this.config.output ??= createDefaultOutput(this.config.browserConsole);
   }
 
   getConfig(): LoggerConfig {
@@ -268,9 +272,7 @@ export class Logger implements ILogger {
   }
 
   private write(output: string): void {
-    const stream =
-      this.config.output ||
-      (typeof process !== 'undefined' && process.stdout ? process.stdout : { write: console.log });
+    const stream = this.config.output || createDefaultOutput(this.config.browserConsole);
     stream.write(output);
   }
 
@@ -358,9 +360,7 @@ export class Logger implements ILogger {
   }
 
   private displayAIInsight(insight: AIInsight): void {
-    const defaultOutput =
-      typeof process !== 'undefined' && process.stdout ? process.stdout.write : console.log;
-    const output = this.config.output?.write || defaultOutput;
+    const output = this.write.bind(this);
     const header = this.config.colors ? chalk.cyan('\nAI Insight:\n') : '\nAI Insight:\n';
     const explanation = this.config.colors
       ? chalk.blue(`   Explanation: ${insight.explanation}\n`)
@@ -460,9 +460,7 @@ export class Logger implements ILogger {
     this.aiService = new AIService();
   }
 
-  private isValidOutputStream(
-    stream: NodeJS.WritableStream | { write: (chunk: string) => void }
-  ): boolean {
+  private isValidOutputStream(stream: LoggerOutput): boolean {
     if (!stream || typeof stream !== 'object') return false;
     if (typeof stream.write !== 'function') return false;
     if (typeof process !== 'undefined' && (stream === process.stdout || stream === process.stderr))

--- a/src/output-policy.ts
+++ b/src/output-policy.ts
@@ -1,0 +1,70 @@
+import type { BrowserConsoleMode, LoggerOutput } from './types';
+
+const noopOutput: LoggerOutput = {
+  write: () => true,
+};
+
+const localHostnamePattern =
+  /^(localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[?::1\]?|.*\.localhost)$/i;
+
+function getHostname(): string {
+  const globalWithLocation = globalThis as typeof globalThis & {
+    location?: { hostname?: string };
+  };
+
+  return globalWithLocation.location?.hostname || '';
+}
+
+export function isBrowserRuntime(): boolean {
+  const globalWithWindow = globalThis as typeof globalThis & {
+    window?: unknown;
+  };
+
+  return globalWithWindow.window !== undefined;
+}
+
+export function isLocalBrowserHost(): boolean {
+  return localHostnamePattern.test(getHostname());
+}
+
+export function shouldUseBrowserConsole(mode: BrowserConsoleMode = 'localhost'): boolean {
+  if (!isBrowserRuntime()) {
+    return false;
+  }
+
+  if (mode === 'always') {
+    return true;
+  }
+
+  if (mode === 'never') {
+    return false;
+  }
+
+  return isLocalBrowserHost();
+}
+
+export function createConsoleOutput(mode: BrowserConsoleMode = 'localhost'): LoggerOutput {
+  if (!shouldUseBrowserConsole(mode)) {
+    return noopOutput;
+  }
+
+  const browserConsole = globalThis.console;
+  if (!browserConsole?.info) {
+    return noopOutput;
+  }
+
+  return {
+    write: (chunk: string) => {
+      browserConsole.info(chunk.trimEnd());
+      return true;
+    },
+  };
+}
+
+export function createDefaultOutput(mode: BrowserConsoleMode = 'localhost'): LoggerOutput {
+  if (typeof process !== 'undefined' && process.stdout) {
+    return process.stdout;
+  }
+
+  return createConsoleOutput(mode);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,10 @@ export type LogData =
   | Error
   | Date;
 
+export type BrowserConsoleMode = 'localhost' | 'always' | 'never';
+
+export type LoggerOutput = NodeJS.WritableStream | { write: (chunk: string) => unknown };
+
 export enum ConfidenceLevel {
   LOW = 0,
   MEDIUM = 1,
@@ -167,7 +171,9 @@ export interface LoggerConfig {
 
   json?: boolean;
 
-  output?: NodeJS.WritableStream | { write: (chunk: string) => void };
+  output?: LoggerOutput;
+
+  browserConsole?: BrowserConsoleMode;
 
   ai?: Partial<AIConfig>;
 }


### PR DESCRIPTION
# Pull Request

## Description

Adds production-safe browser console defaults so bundled web apps do not write to Chrome DevTools on non-local hosts unless the user opts in.

- Adds `browserConsole: 'localhost' | 'always' | 'never'`, defaulting to localhost-only browser console output
- Centralizes default output handling for public logger writes and internal diagnostics
- Preserves explicit custom `output` streams as the highest-priority override
- Bumps the package to `1.3.0` and adds the changelog entry for the release
- Enforces configured AI rate limits before external provider calls

## How to Test

1. `pnpm audit --json`
2. `pnpm type-check`
3. `pnpm test -- --runInBand`
4. `pnpm lint`
5. `pnpm build`

## Additional Information

Planned release tag after merge: `v1.3.0`. I did not push the tag before merge to avoid publishing/releasing an unmerged PR branch.