### PR TITLE
ci: fix npm-only pack step

### DIFF
--- a/.github/workflows/npm-publish-only.yml
+++ b/.github/workflows/npm-publish-only.yml
@@ -146,7 +146,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .npm-release
-          TARBALL="$(npm pack --pack-destination .npm-release --json | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data)[0].filename));")"
+          TARBALL="$(npm pack --ignore-scripts --pack-destination .npm-release --json | node -e "let data=''; process.stdin.on('data', chunk => data += chunk); process.stdin.on('end', () => console.log(JSON.parse(data)[0].filename));")"
           echo "tarball=.npm-release/$TARBALL" >> "$GITHUB_OUTPUT"
           echo "Packed $TARBALL"
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes the npm-only publish workflow pack step so `npm pack --json` is not polluted by the package `prepare` script output.

- Uses `npm pack --ignore-scripts` after the workflow has already run `pnpm build`
- Keeps the release tarball generated from the validated build output

## How to Test

1. `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/npm-publish-only.yml'); puts 'yaml ok'"`

## Additional Information

This unblocks rerunning the failed `NPM Publish Only` workflow for `v1.3.0`. 