### PR TITLE
ci: support npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish-only.yml
+++ b/.github/workflows/npm-publish-only.yml
@@ -17,6 +17,14 @@ on:
           - latest
           - next
           - canary
+      auth_mode:
+        description: 'npm authentication mode'
+        required: true
+        default: trusted-publishing
+        type: choice
+        options:
+          - trusted-publishing
+          - token
       dry_run:
         description: 'Run all checks and npm publish --dry-run without publishing'
         required: true
@@ -74,7 +82,7 @@ jobs:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release-tag }}
       NPM_DIST_TAG: ${{ inputs.dist_tag || 'latest' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_AUTH_MODE: ${{ inputs.auth_mode || 'trusted-publishing' }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@v4
@@ -150,8 +158,27 @@ jobs:
           echo "tarball=.npm-release/$TARBALL" >> "$GITHUB_OUTPUT"
           echo "Packed $TARBALL"
 
-      - name: Publish to npm
-        if: steps.version.outputs.already-published != 'true'
+      - name: Publish to npm with trusted publishing
+        if: steps.version.outputs.already-published != 'true' && env.NPM_AUTH_MODE == 'trusted-publishing'
+        run: |
+          set -euo pipefail
+
+          if [ "$DRY_RUN" = "true" ]; then
+            npm publish "${{ steps.pack.outputs.tarball }}" \
+              --access public \
+              --tag "$NPM_DIST_TAG" \
+              --dry-run
+          else
+            npm publish "${{ steps.pack.outputs.tarball }}" \
+              --access public \
+              --tag "$NPM_DIST_TAG" \
+              --provenance
+          fi
+
+      - name: Publish to npm with token
+        if: steps.version.outputs.already-published != 'true' && env.NPM_AUTH_MODE == 'token'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -175,6 +202,7 @@ jobs:
             echo "- Release tag: \`$RELEASE_TAG\`"
             echo "- Package: \`${{ steps.version.outputs.package-name }}@${{ steps.version.outputs.package-version }}\`"
             echo "- npm dist-tag: \`$NPM_DIST_TAG\`"
+            echo "- Auth mode: \`$NPM_AUTH_MODE\`"
             echo "- Dry run: \`$DRY_RUN\`"
             echo "- Already published: \`${{ steps.version.outputs.already-published }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -175,6 +175,7 @@ Run it from the Actions tab with:
 
 - `release_tag`: `latest` or a specific tag such as `v1.3.0`
 - `dist_tag`: `latest`
+- `auth_mode`: `trusted-publishing` when npm package trusted publishing is configured, or `token` for `NPM_TOKEN`
 - `dry_run`: `false` to publish, `true` to verify without publishing
 
 This workflow publishes only to npm. It does not create GitHub releases or tags, and it skips safely if the package version is already present on npm.


### PR DESCRIPTION
## Summary
- add an `auth_mode` input to the npm-only publish workflow
- support npm Trusted Publishing as the default publish path
- keep `NPM_TOKEN` publishing available as an explicit fallback
- document the npm-only recovery inputs in `RELEASE.md`

## Root Cause
The `v1.3.0` npm recovery run reached `npm publish`, but npm rejected the token publish with `EOTP`, meaning the current token path still requires a one-time password. GitHub Actions cannot provide interactive OTP input, so the workflow needs a non-interactive publishing mode.

## Release Impact
This does not change package code. It only updates release automation so `@calphonse/logger@1.3.0` can be published from the existing GitHub release/tag once npm auth is configured for either:

- `trusted-publishing`: npm Trusted Publishing configured for this repo/workflow
- `token`: an npm automation token that does not require OTP during publish

## Validation
- parsed `.github/workflows/npm-publish-only.yml` with Ruby YAML loader
